### PR TITLE
Updated deprecated function

### DIFF
--- a/firmware/application.cpp
+++ b/firmware/application.cpp
@@ -53,7 +53,7 @@ void saveTemperature()
   sFLASH_EraseSector(DESIRED_TEMP_FLASH_ADDRESS);
   Serial.println("Saving temperature to flash");
   uint8_t values[2] = { (uint8_t)desiredTemperature, 0 };
-  sFLASH_WritePage(values, DESIRED_TEMP_FLASH_ADDRESS, 2);
+  sFLASH_WriteBytes(values, DESIRED_TEMP_FLASH_ADDRESS, 2);
 }
 
 void loadTemperature()


### PR DESCRIPTION
sFLASH_WritePage to sFLASH_WriteBytes as noted in https://github.com/spark/core-common-lib/commit/55e0a056ec748968f747a8d07ec9a0fddf44aedc#diff-779c7ec039ee4ca66b5552dd9a74e92bL163
